### PR TITLE
Add form instructions for screen readers

### DIFF
--- a/app/views/records/_form_header.html.erb
+++ b/app/views/records/_form_header.html.erb
@@ -1,4 +1,5 @@
-    <h2 class="non lower">
-	  <%= t('hydra_editor.form.title') %>
-	  <small class="pull-right"><span class="error">*</span> <%= t('hydra_editor.form.required_fields') %></small> 
-	</h2>
+<p class="instructions"><%= t('hydra_editor.form.instructions') %></p>
+<h2 class="non lower">
+  <%= t('hydra_editor.form.title') %>
+  <small class="pull-right"><span class="error">*</span> <%= t('hydra_editor.form.required_fields') %></small>
+</h2>

--- a/app/views/records/_form_header.html.erb
+++ b/app/views/records/_form_header.html.erb
@@ -1,4 +1,4 @@
-<p class="instructions"><%= t('hydra_editor.form.instructions') %></p>
+<p class="instructions"><%= raw t('hydra_editor.form.instructions') %></p>
 <h2 class="non lower">
   <%= t('hydra_editor.form.title') %>
   <small class="pull-right"><span class="error">*</span> <%= t('hydra_editor.form.required_fields') %></small>

--- a/app/views/records/_form_header.html.erb
+++ b/app/views/records/_form_header.html.erb
@@ -1,4 +1,4 @@
-<p class="instructions"><%= raw t('hydra_editor.form.instructions') %></p>
+<p class="instructions"><%= t('hydra_editor.form.instructions_html') %></p>
 <h2 class="non lower">
   <%= t('hydra_editor.form.title') %>
   <small class="pull-right"><span class="error">*</span> <%= t('hydra_editor.form.required_fields') %></small>

--- a/config/locales/hydra_editor.yml
+++ b/config/locales/hydra_editor.yml
@@ -8,5 +8,8 @@ en:
     form:
       title: 'Descriptions'
       required_fields: 'indicates required fields'
+      instructions: 'Use the tab key to navigate the form, press space when
+                    focused on a button to add or remove fields, and press
+                    enter to submit when focused on simple text fields.'
     new:
       title: 'Create a New %s Record'

--- a/config/locales/hydra_editor.yml
+++ b/config/locales/hydra_editor.yml
@@ -8,8 +8,8 @@ en:
     form:
       title: 'Descriptions'
       required_fields: 'indicates required fields'
-      instructions: 'Use the <kbd>Tab</kbd> key to navigate the form, press
-                    <kbd>Space</kbd> to activate a button, and press
-                    <kbd>Enter</kbd> to submit the whole form.'
+      instructions_html: 'Use the <kbd>Tab</kbd> key to navigate the form, press
+                         <kbd>Space</kbd> to activate a button, and press
+                         <kbd>Enter</kbd> to submit the whole form.'
     new:
       title: 'Create a New %s Record'

--- a/config/locales/hydra_editor.yml
+++ b/config/locales/hydra_editor.yml
@@ -8,8 +8,8 @@ en:
     form:
       title: 'Descriptions'
       required_fields: 'indicates required fields'
-      instructions: 'Use the tab key to navigate the form, press space when
-                    focused on a button to add or remove fields, and press
-                    enter to submit when focused on simple text fields.'
+      instructions: 'Use the <kbd>Tab</kbd> key to navigate the form, press
+                    <kbd>Space</kbd> to activate a button, and press
+                    <kbd>Enter</kbd> to submit the whole form.'
     new:
       title: 'Create a New %s Record'


### PR DESCRIPTION
Adds very basic explanation of the tab/enter keys for keyboard-only users (or users who simply prefer the keyboard)