### PR TITLE
Use classes for input field generation

### DIFF
--- a/app/assets/javascripts/hydra-editor/editMetadata.js
+++ b/app/assets/javascripts/hydra-editor/editMetadata.js
@@ -1,3 +1,3 @@
 Blacklight.onLoad(function() {
-  $('.multi_value.form-group').manage_fields();
+  $('.repeating-field.form-group').manage_fields();
 });

--- a/app/forms/hydra_editor/fields/factory.rb
+++ b/app/forms/hydra_editor/fields/factory.rb
@@ -1,0 +1,13 @@
+module HydraEditor
+  module Fields
+    class Factory
+      def self.create(object, property)
+        if object.class.multiple?(property)
+          MultiInput.new object, property
+        else
+          Input.new object, property
+        end
+      end
+    end
+  end
+end

--- a/app/forms/hydra_editor/fields/generator.rb
+++ b/app/forms/hydra_editor/fields/generator.rb
@@ -1,0 +1,29 @@
+module HydraEditor
+  module Fields
+    class Generator
+      class << self
+        attr_writer :factory
+
+        def factory
+          @factory ||= HydraEditor::Fields::Factory
+        end
+      end
+
+      attr_reader :form, :field
+      attr_writer :factory
+
+      def initialize(form, key)
+        @form = form
+        @field = factory.create(form.object, key)
+      end
+
+      def factory
+        @factory ||= self.class.factory
+      end
+
+      def input
+        form.input field.property, field.options
+      end
+    end
+  end
+end

--- a/app/forms/hydra_editor/fields/input.rb
+++ b/app/forms/hydra_editor/fields/input.rb
@@ -1,0 +1,29 @@
+module HydraEditor
+  module Fields
+    class Input
+      attr_accessor :object, :property, :field_type, :input_html_options, :wrapper_html_options
+
+      def initialize(object, property)
+        @object = object
+        @property = property
+      end
+
+      def required?
+        return object.required?(property)
+      end
+
+      def all_options
+        {
+          required: required?,
+          as: field_type,
+          input_html: input_html_options,
+          wrapper_html: wrapper_html_options,
+        }
+      end
+
+      def options
+        all_options.select {|k,v| v != nil}
+      end
+    end
+  end
+end

--- a/app/forms/hydra_editor/fields/multi_input.rb
+++ b/app/forms/hydra_editor/fields/multi_input.rb
@@ -1,0 +1,13 @@
+module HydraEditor
+  module Fields
+    class MultiInput  < Input
+      def initialize(object, property)
+        super
+
+        @field_type = :multi_value
+        @input_html_options = { class: "form-control" }
+        @wrapper_html_options = { class: "repeating-field" }
+      end
+    end
+  end
+end

--- a/app/forms/hydra_editor/form.rb
+++ b/app/forms/hydra_editor/form.rb
@@ -6,6 +6,7 @@ module HydraEditor
 
     include Hydra::Presenter
     included do
+      attr_writer :field_generator
       class_attribute :required_fields
       self.required_fields = []
       delegate :errors, to: :model
@@ -14,6 +15,10 @@ module HydraEditor
     def initialize(model)
       super
       initialize_fields
+    end
+
+    def generate_input(form, key)
+      field_generator.new(form, key).input
     end
 
     def required?(key)
@@ -26,6 +31,10 @@ module HydraEditor
 
     def []=(key, value)
       @attributes[key.to_s] = value
+    end
+
+    def field_generator
+      @field_generator ||= HydraEditor::Fields::Generator
     end
 
     class Validator < ActiveModel::Validations::PresenceValidator

--- a/app/views/records/edit_fields/_default.html.erb
+++ b/app/views/records/edit_fields/_default.html.erb
@@ -1,5 +1,1 @@
-<% if f.object.class.multiple? key %>
-  <%= f.input key, as: :multi_value, input_html: { class: 'form-control' }, required: f.object.required?(key) %>
-<% else %>
-  <%= f.input key, required: f.object.required?(key) %>
-<% end %>
+<%= f.object.generate_input(f, key) %>

--- a/spec/forms/hydra_editor_field_factory_spec.rb
+++ b/spec/forms/hydra_editor_field_factory_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe HydraEditor::Fields::Factory do
+  subject { HydraEditor::Fields::Factory.create(object, property) }
+  let(:object) { double("form object") }
+  let(:object_class) { double("form object class") }
+  let(:property) { :property }
+
+  before do
+    allow(object).to receive(:class).and_return(object_class)
+    allow(object_class).to receive(:multiple?).with(property).and_return(multiple)
+  end
+
+  describe ".create" do
+    context "when multiple is true" do
+      let(:multiple) { true }
+      it { is_expected.to be_instance_of(HydraEditor::Fields::MultiInput) }
+    end
+
+    context "when multiple is false" do
+      let(:multiple) { false }
+      it { is_expected.to be_instance_of(HydraEditor::Fields::Input) }
+    end
+  end
+end

--- a/spec/forms/hydra_editor_field_generator_spec.rb
+++ b/spec/forms/hydra_editor_field_generator_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe HydraEditor::Fields::Generator do
+  subject { HydraEditor::Fields::Generator }
+
+  describe ".new" do
+    let(:factory) { class_double("HydraEditor::Fields::Factory") }
+    let(:key) { :key }
+    let(:form) { double("form") }
+    let(:object) { double("form.object") }
+    let(:field) { double("field") }
+
+    it "builds a field using its factory" do
+      expect(subject).to receive(:factory).and_return(factory)
+      expect(form).to receive(:object).and_return(object)
+      expect(factory).to receive(:create).with(object, key).and_return(field)
+
+      generator = subject.new(form, key)
+      expect(generator.field).to eq(field)
+    end
+  end
+
+  describe ".factory" do
+    subject { HydraEditor::Fields::Generator.factory }
+    it { is_expected.to eq(HydraEditor::Fields::Factory) }
+  end
+end

--- a/spec/forms/hydra_editor_field_input_spec.rb
+++ b/spec/forms/hydra_editor_field_input_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe HydraEditor::Fields::Input do
+  let(:input) { HydraEditor::Fields::Input.new(object, property) }
+  let(:object) { double("form object") }
+  let(:property) { :property }
+
+  describe "#options" do
+    subject { input.options }
+    let(:required) { double("required") }
+
+    before do
+      allow(object).to receive(:required?).with(:property).and_return(required)
+    end
+
+    context "when fields are left as-is" do
+      it { is_expected.to match(:required => required) }
+    end
+
+    context "when field_type is defined" do
+      before do
+        input.field_type = :foo
+      end
+      it { is_expected.to include(:as => :foo) }
+    end
+
+    context "when input_html_options is defined" do
+      before do
+        input.input_html_options = :bar
+      end
+      it { is_expected.to include(:input_html => :bar) }
+    end
+
+    context "when wrapper_html_options is defined" do
+      before do
+        input.wrapper_html_options = :bar
+      end
+      it { is_expected.to include(:wrapper_html => :bar) }
+    end
+  end
+end

--- a/spec/forms/hydra_editor_field_multi_input_spec.rb
+++ b/spec/forms/hydra_editor_field_multi_input_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe HydraEditor::Fields::MultiInput do
+  let(:input) { HydraEditor::Fields::MultiInput.new(object, property) }
+  let(:object) { double("form object") }
+  let(:property) { :property }
+
+  describe "#options" do
+    subject { input.options }
+    let(:required) { double("required") }
+
+    before do
+      allow(object).to receive(:required?).with(:property).and_return(required)
+    end
+
+    it { is_expected.to match(:required => required, :as => :multi_value,
+                              :input_html => { class: "form-control" },
+                              :wrapper_html => { class: "repeating-field" }) }
+  end
+end

--- a/spec/forms/hydra_editor_form_spec.rb
+++ b/spec/forms/hydra_editor_form_spec.rb
@@ -91,4 +91,25 @@ describe HydraEditor::Form do
     end
 
   end
+
+  describe "#generate_input" do
+    let(:generator_class) { class_double(HydraEditor::Fields::Generator) }
+    let(:generator) { instance_double(HydraEditor::Fields::Generator) }
+
+    it "delegates to the field generator" do
+      expect(form).to receive(:field_generator).and_return(generator_class)
+      expect(generator_class).to receive(:new).with(:form, :key).and_return(generator)
+      expect(generator).to receive(:input)
+
+      form.generate_input(:form, :key)
+    end
+  end
+
+  describe "#field_generator" do
+    context "when left untouched" do
+      it "defaults to HydraEditor::Fields::Generator" do
+        expect(form.field_generator).to eq(HydraEditor::Fields::Generator)
+      end
+    end
+  end
 end

--- a/spec/views/records/edit_fields/_default.html.erb_spec.rb
+++ b/spec/views/records/edit_fields/_default.html.erb_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe 'records/edit_fields/_default' do
-  let(:form) { SimpleForm::FormBuilder.new(:foo, audio, view, {}) }
+  let(:form) { SimpleForm::FormBuilder.new(:foo, audio_form, view, {}) }
+  let(:audio_form) { AudioForm.new(audio) }
   let(:audio) { Audio.new }
 
   before do


### PR DESCRIPTION
- Adds interceptable / overridable pieces to the form field creation
- Uses more general "repeating-field" class for CSS to avoid relying on
  Ruby's class name
- Retains previous behavior for apps not customizing the form builders