### PR TITLE
Don't test Fedora 4, and clean up testing on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
 language: ruby
+cache: bundler
+sudo: false
 rvm:
-  - 2.1
-  - 2.0
-
-gemfile:
-  - gemfiles/gemfile.rails4
-  - gemfiles/gemfile.rails4.1
-  - gemfiles/gemfile.rails4.2
-
+  - 2.2
+env:
+  global:
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+  matrix:
+    - "RAILS_VERSION=4.1.8"
+    - "RAILS_VERSION=4.2.3"
+matrix:
+  allow_failures:
+    - env: "RAILS_VERSION=4.1.8"
 notifications:
   irc: "irc.freenode.org#projecthydra"
+before_script:
+  - jdk_switcher use oraclejdk8

--- a/Gemfile
+++ b/Gemfile
@@ -7,12 +7,18 @@ gemspec path: File.expand_path('..', __FILE__)
 
 # To use debugger
 # gem 'debugger'
-#
-gem 'sass', '~> 3.2.15'
-gem 'sprockets', '~> 2.11.0'
 
 file = File.expand_path("Gemfile", ENV['ENGINE_CART_DESTINATION'] || ENV['RAILS_ROOT'] || File.expand_path("../spec/internal", __FILE__))
 if File.exists?(file)
   puts "Loading #{file} ..." if $DEBUG # `ruby -d` or `bundle -v`
   instance_eval File.read(file)
+else
+  gem 'rails', ENV['RAILS_VERSION'] if ENV['RAILS_VERSION']
+
+  if ENV['RAILS_VERSION'] and ENV['RAILS_VERSION'] !~ /^4.2/
+    gem 'sass-rails', "< 5.0"
+  else
+    gem 'responders', "~> 2.0"
+    gem 'sass-rails', ">= 5.0"
+  end
 end

--- a/hydra-editor.gemspec
+++ b/hydra-editor.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", ">= 3.2.13", "< 5.0"
   s.add_dependency 'bootstrap_form', '~> 2.1.1'
-  s.add_dependency "active-fedora", ">= 6.3.0"
+  s.add_dependency "active-fedora", ">= 6.3.0", "< 9.0"
   s.add_dependency "cancancan"
 
   s.add_development_dependency "sqlite3"

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -1,0 +1,3 @@
+gem 'active-fedora', '< 9.0'
+gem 'blacklight'
+gem 'hydra-head'

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -1,14 +1,7 @@
 require 'rails/generators'
 
 class TestAppGenerator < Rails::Generators::Base
-
-  def add_gems
-    gem 'blacklight'
-    gem 'hydra-head'
-    Bundler.with_clean_env do
-      run "bundle install"
-    end
-  end
+  source_root "./spec/test_app_templates"
 
   def run_blacklight_generator
     say_status("warning", "GENERATING BL", :yellow)


### PR DESCRIPTION
Versions < 1.0 should not test Fedora4. Also need to clean up the testing process to support Rails 4.2.