### PR TITLE
Pin bootstrap-sass to 3.3.4.1 for rails 4.1 build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ else
   gem 'rails', ENV['RAILS_VERSION'] if ENV['RAILS_VERSION']
 
   if ENV['RAILS_VERSION'] and ENV['RAILS_VERSION'] !~ /^4.2/
+    gem "bootstrap-sass", "3.3.4.1"
     gem 'sass-rails', "< 5.0"
   else
     gem 'responders', "~> 2.0"


### PR DESCRIPTION
This relates to sass/sass#1656. bootstrap-sass 3.3.5 introduced a
regression which causes the Blacklight default CSS to fail its build.