### PR TITLE
Add an instance method version of multiple?

### DIFF
--- a/app/forms/hydra_editor/form.rb
+++ b/app/forms/hydra_editor/form.rb
@@ -45,6 +45,14 @@ module HydraEditor
         end
       end
 
+      def multiple?(field)
+        if reflection = model_class.reflect_on_association(field)
+          reflection.collection?
+        else
+          model_class.multiple?(field)
+        end
+      end
+
       # Return a hash of all the parameters from the form as a hash.
       # This is typically used by the controller as the main read interface to the form.
       # This hash can then be used to create or update an object in the data store.
@@ -90,7 +98,7 @@ module HydraEditor
       # override this method if you need to initialize more complex RDF assertions (b-nodes)
       def initialize_field(key)
         # if value is empty, we create an one element array to loop over for output
-        if self.class.multiple?(key)
+        if multiple?(key)
           self[key] = ['']
         else
           self[key] = ''

--- a/app/presenters/hydra/presenter.rb
+++ b/app/presenters/hydra/presenter.rb
@@ -3,6 +3,10 @@ module Hydra
     extend ActiveSupport::Concern
     included do
       attr_reader :model
+
+      # model_class only needs to be set if you are using the
+      # deprecated class methods multiple? or unique? or if you
+      # need to use +model_name+ method or if this class includes Hydra::Editor::Form.
       class_attribute :model_class
     end
 
@@ -51,8 +55,18 @@ module Hydra
       self.class._terms
     end
 
+    def multiple?(field)
+      if reflection = model.class.reflect_on_association(field)
+        reflection.collection?
+      else
+        model.class.multiple?(field)
+      end
+    end
+
     module ClassMethods
+      # @deprecated Because if we use an instance method, there will be no need to set self.model_class in most instances. Note, there is a class method multiple? on the form.
       def multiple?(field)
+        Deprecation.warn(ClassMethods, "The class method multiple? has been deprecated. Use the instance method instead. This will be removed in version 2.0")
         if reflection = model_class.reflect_on_association(field)
           reflection.collection?
         else
@@ -61,6 +75,7 @@ module Hydra
       end
 
       def unique?(field)
+        Deprecation.warn(ClassMethods, "The class method unique? has been deprecated. Use the instance method 'multiple?' instead. This will be removed in version 2.0")
         if reflection = model_class.reflect_on_association(field)
           !reflection.collection?
         else

--- a/app/views/records/edit_fields/_default.html.erb
+++ b/app/views/records/edit_fields/_default.html.erb
@@ -1,4 +1,4 @@
-<% if f.object.class.multiple? key %>
+<% if f.object.multiple? key %>
   <%= f.input key, as: :multi_value, input_html: { class: 'form-control' }, required: f.object.required?(key) %>
 <% else %>
   <%= f.input key, required: f.object.required?(key) %>

--- a/spec/presenters/hydra_editor_presenter_spec.rb
+++ b/spec/presenters/hydra_editor_presenter_spec.rb
@@ -68,30 +68,58 @@ describe Hydra::Presenter do
   end
 
   describe "multiple?" do
-    subject { TestPresenter.multiple?(field) }
+    describe "instance method" do
+      subject { presenter.multiple?(field) }
 
-    context "for a multivalue string" do
-      let(:field) { :title }
-      it { is_expected.to be true }
+      context "for a multivalue string" do
+        let(:field) { :title }
+        it { is_expected.to be true }
+      end
+
+      context "for a single value string" do
+        let(:field) { :creator }
+        it { is_expected.to be false }
+      end
+
+      context "for a multivalue association" do
+        let(:field) { :contributors }
+        it { is_expected.to be true }
+      end
+
+      context "for a single value association" do
+        let(:field) { :publisher }
+        it { is_expected.to be false }
+      end
     end
 
-    context "for a single value string" do
-      let(:field) { :creator }
-      it { is_expected.to be false }
-    end
+    describe "class method" do
+      before { allow(Deprecation).to receive(:warn) }
+      subject { TestPresenter.multiple?(field) }
 
-    context "for a multivalue association" do
-      let(:field) { :contributors }
-      it { is_expected.to be true }
-    end
+      context "for a multivalue string" do
+        let(:field) { :title }
+        it { is_expected.to be true }
+      end
 
-    context "for a single value association" do
-      let(:field) { :publisher }
-      it { is_expected.to be false }
+      context "for a single value string" do
+        let(:field) { :creator }
+        it { is_expected.to be false }
+      end
+
+      context "for a multivalue association" do
+        let(:field) { :contributors }
+        it { is_expected.to be true }
+      end
+
+      context "for a single value association" do
+        let(:field) { :publisher }
+        it { is_expected.to be false }
+      end
     end
   end
 
   describe "unique?" do
+    before { allow(Deprecation).to receive(:warn) }
     subject { TestPresenter.unique?(field) }
 
     context "for a multivalue string" do

--- a/spec/views/records/edit_fields/_default.html.erb_spec.rb
+++ b/spec/views/records/edit_fields/_default.html.erb_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe 'records/edit_fields/_default' do
-  let(:form) { SimpleForm::FormBuilder.new(:foo, audio, view, {}) }
+  let(:form) { SimpleForm::FormBuilder.new(:foo, audio_form, view, {}) }
+  let(:audio_form) { AudioForm.new(audio) }
   let(:audio) { Audio.new }
 
   before do


### PR DESCRIPTION
to the presenter.  Deprecate the class versions of `multiple?` and `unique?`
on the presenter, but moved a non-deprecated class verison of `multiple?`
to the `Form`.  Presenters generally shouldn't need to deal with setting
`model_class`, so when these deprecated methods are removed we can get rid
of that.