### PR TITLE
Use class selector for specifying a field's children

### DIFF
--- a/app/assets/javascripts/hydra-editor/field_manager.es6
+++ b/app/assets/javascripts/hydra-editor/field_manager.es6
@@ -82,7 +82,7 @@ export class FieldManager {
 
     createNewField($activeField) {
         let $newField = $activeField.clone();
-        let $newChildren = $newField.children('input');
+        let $newChildren = $newField.children('.multi_value');
         $newChildren.val('').removeProp('required');
         $newChildren.first().focus();
         this.element.trigger("managed_field:add", $newChildren.first());


### PR DESCRIPTION
Fixes https://github.com/projecthydra/sufia/issues/2705

Uses the class selector instead of actual html tag. This allows for any kind of tag to be used, such as `input` or `textarea`.