### PR TITLE
Test for adding input or textarea child fields

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -33,6 +33,8 @@ require 'engine_cart/rake_task'
 require 'jasmine'
 load 'jasmine/tasks/jasmine.rake'
 
+import "#{Gem.loaded_specs['jasmine'].full_gem_path}/lib/jasmine/tasks/jasmine.rake"
+
 # Set up the test application prior to running jasmine tasks.
 task 'jasmine:require' => :setup_test_server
 task :setup_test_server do

--- a/app/assets/javascripts/hydra-editor/field_manager.es6
+++ b/app/assets/javascripts/hydra-editor/field_manager.es6
@@ -82,10 +82,8 @@ export class FieldManager {
 
     createNewField($activeField) {
         let $newField = $activeField.clone();
-        let $newChildren = $newField.children('.multi_value');
-        $newChildren.val('').removeProp('required');
-        $newChildren.first().focus();
-        this.element.trigger("managed_field:add", $newChildren.first());
+        let $newChildren = this.createNewChildren($newField);
+        this.element.trigger("managed_field:add", $newChildren);
         return $newField;
     }
 
@@ -145,5 +143,12 @@ export class FieldManager {
         $removeHtml.find('.controls-remove-text').html(options.removeText);
         $removeHtml.find('.controls-field-name-text').html(options.label);
         return $removeHtml;
+    }
+
+    createNewChildren(clone) {
+        let $newChildren = $(clone).children('.multi_value');
+        $newChildren.val('').removeProp('required');
+        $newChildren.first().focus();
+        return $newChildren.first();
     }
 }

--- a/spec/javascripts/manage_fields_spec.js
+++ b/spec/javascripts/manage_fields_spec.js
@@ -20,4 +20,24 @@ describe("FieldManager", function() {
       expect(element.find('button.remove')).toExist()
     });
   });
+
+  describe("#createNewChildren", function() {
+    it("removes values and properties from an input tag", function() {
+      var field = '<li class="field-wrapper"><input class="string multi_value optional text_title form-control multi-text-field" name="text[title][]" value="sample value" required id="text_title" aria-labelledby="text_title_label" type="text" /></li>'      
+      expect($(field).find('input').val()).toEqual('sample value')
+      expect($(field).find('input').attr('required')).toEqual('required');      
+      var child = target.createNewChildren($(field))
+      expect(child.val()).toEqual('')
+      expect(child.attr('required')).toBeUndefined();
+    })
+
+    it("removes values and properties from a textarea tag", function() {
+      var field = '<li class="field-wrapper"><textarea class="string multi_value optional text_title form-control multi-text-field" name="text[title][]" required id="text_title" aria-labelledby="text_title_label">sample value</textarea></li>'      
+      expect($(field).find('textarea').val()).toEqual('sample value')
+      expect($(field).find('textarea').attr('required')).toEqual('required');      
+      var child = target.createNewChildren($(field))
+      expect(child.val()).toEqual('')
+      expect(child.attr('required')).toBeUndefined();
+    })    
+  })
 });


### PR DESCRIPTION
Extracts behavior of creating new child fields to a separate method for easier testing. Provides test coverage for previous commit as requested by @jcoyne.