### PR TITLE
Allow setting a custom field_metadata_service

### DIFF
--- a/app/forms/hydra_editor/form.rb
+++ b/app/forms/hydra_editor/form.rb
@@ -46,7 +46,7 @@ module HydraEditor
       end
 
       def multiple?(field)
-        HydraEditor::FieldMetadataService.multiple?(model_class, field)
+        field_metadata_service.multiple?(model_class, field)
       end
 
       # Return a hash of all the parameters from the form as a hash.

--- a/app/presenters/hydra/presenter.rb
+++ b/app/presenters/hydra/presenter.rb
@@ -32,6 +32,13 @@ module Hydra
     include ActiveModelPresenter
     included do
       class_attribute :_terms, instance_accessor: false
+
+      # You may want to set your own field_metadata_service that can 
+      # answer the questions about a fields cardinality regardless of the 
+      # cardinality of the model
+      class_attribute :field_metadata_service
+      # This default service just give us the cardiality defined in the model.
+      self.field_metadata_service = HydraEditor::FieldMetadataService
     end
 
     def terms
@@ -42,14 +49,14 @@ module Hydra
     # If the field is a property, delegate to the property.
     # Otherwise return false
     def multiple?(field)
-      HydraEditor::FieldMetadataService.multiple?(model.class, field)
+      field_metadata_service.multiple?(model.class, field)
     end
 
     module ClassMethods
       # @deprecated Because if we use an instance method, there will be no need to set self.model_class in most instances. Note, there is a class method multiple? on the form.
       def multiple?(field)
         Deprecation.warn(ClassMethods, 'The class method multiple? has been deprecated. Use the instance method instead. This will be removed in version 2.0')
-        HydraEditor::FieldMetadataService.multiple?(model_class, field)
+        field_metadata_service.multiple?(model_class, field)
       end
 
       def unique?(field)

--- a/spec/forms/hydra_editor_form_spec.rb
+++ b/spec/forms/hydra_editor_form_spec.rb
@@ -90,4 +90,21 @@ describe HydraEditor::Form do
       end
     end
   end
+
+  describe ".field_metadata_service" do
+    before do
+      class CustomMetadataService
+      end
+    end
+
+    after do
+      Object.send(:remove_const, :CustomMetadataService)
+    end
+
+    it "is settable" do
+      expect { TestForm.field_metadata_service = CustomMetadataService }.to change { TestForm.field_metadata_service }
+        .from(HydraEditor::FieldMetadataService)
+        .to(CustomMetadataService)
+    end
+  end
 end


### PR DESCRIPTION
This allows us to decouple the cardinality of the form fields from
the cardinality defined in the model.