### PR TITLE
Use ActiveModel::Naming to find partials

### DIFF
--- a/app/helpers/concerns/records_helper_behavior.rb
+++ b/app/helpers/concerns/records_helper_behavior.rb
@@ -12,7 +12,7 @@ module RecordsHelperBehavior
   end
 
   def render_edit_field_partial(field_name, locals)
-    collection = ActiveSupport::Inflector.tableize(locals[:f].object.class.to_s)
+    collection = locals[:f].object.model_name.collection
     render_edit_field_partial_with_action(collection, field_name, locals)
   end
 

--- a/spec/helpers/records_helper_spec.rb
+++ b/spec/helpers/records_helper_spec.rb
@@ -15,8 +15,12 @@ describe RecordsHelper do
 
   describe 'render_edit_field_partial' do
     before do
-      class Dragon; end
-      class Serpent; end
+      class Dragon
+        extend ActiveModel::Naming
+      end
+      class Serpent
+        extend ActiveModel::Naming
+      end
     end
     let(:f) { double('form') }
     it 'draws partial elements based on class of the object' do


### PR DESCRIPTION
This enables Hyrax to use presenters to use a path like
`app/views/collections/edit_partials` rather than
`app/views/hyrax/form/collection_edit_forms/edit_partials`